### PR TITLE
Syntax fixes for Swift 1.2

### DIFF
--- a/SleepDisplay/main.swift
+++ b/SleepDisplay/main.swift
@@ -21,7 +21,7 @@ import Foundation
 
 var shouldWake = false
 
-if let downcastArgs = NSProcessInfo.processInfo().arguments as? String[] {
+if let downcastArgs = NSProcessInfo.processInfo().arguments as? [String] {
     for arg in downcastArgs {
         switch arg {
         case "-wake", "--wake", "-w":


### PR DESCRIPTION
Fixes build errors with Xcode 6.3 / Swift 1.2